### PR TITLE
Add gh-pages deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,23 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm run build
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_branch: gh-pages
+          publish_dir: ./build

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ npm run build
 
 This command bundles the app and outputs the optimized files to the `build` directory. The files from this directory can be served on any static hosting provider.
 
+## Deployment
+
+Pushes to the `main` branch automatically build and deploy the latest version of the app to the `gh-pages` branch using GitHub Actions. The workflow installs dependencies, runs the production build, and publishes the contents of the `build/` directory with [peaceiris/actions-gh-pages](https://github.com/peaceiris/actions-gh-pages).
+
 ## Design Guidelines & Coding Standards
 
 - Follows React best practices with functional components and hooks.


### PR DESCRIPTION
## Summary
- add deploy workflow for GitHub Pages
- document automatic deployment

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*