### PR TITLE
Add about page and navigation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@mui/material": "^7.1.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       },
@@ -3586,6 +3587,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/plugin-babel": {
@@ -14922,6 +14932,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-scripts": {

--- a/package.json
+++ b/package.json
@@ -15,11 +15,20 @@
     "@mui/material": "^7.1.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-router-dom": "^6.23.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^14.0.0"
+  },
+  "browserslist": {
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
   }
 }

--- a/src/AboutPage.js
+++ b/src/AboutPage.js
@@ -1,0 +1,159 @@
+import React from 'react';
+import {
+  Container,
+  Card,
+  CardContent,
+  Typography,
+  Box,
+  Stack,
+  Divider,
+  Avatar,
+  Button,
+} from '@mui/material';
+import { Link as RouterLink } from 'react-router-dom';
+
+const AboutPage = () => {
+  return (
+    <Container
+      maxWidth="md"
+      sx={{
+        py: { xs: 6, sm: 8 },
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <Card
+        sx={{
+          width: '100%',
+          borderRadius: 4,
+          background: 'rgba(255, 255, 255, 0.92)',
+          backdropFilter: 'blur(18px)',
+          boxShadow: '0 20px 45px rgba(37, 99, 235, 0.25)',
+        }}
+      >
+        <CardContent sx={{ p: { xs: 3, sm: 5 } }}>
+          <Typography variant="h4" align="center" gutterBottom>
+            About Tax Strategy Calculator
+          </Typography>
+          <Typography
+            variant="body1"
+            color="text.secondary"
+            align="center"
+            sx={{ mb: 4 }}
+          >
+            Tax Strategy Calculator is a learning tool for UK investors, founders, and
+            employees who want a clearer picture of how income, dividends, and capital
+            gains interact. It brings the rules for allowances, tax bands, and reliefs
+            into a single, interactive view so you can explore scenarios with confidence.
+          </Typography>
+
+          <Stack spacing={4}>
+            <Box>
+              <Typography variant="h6" gutterBottom>
+                Why the app exists
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                Understanding UK tax planning usually requires piecing together dense
+                guidance from HMRC, accountants, and finance blogs. This app condenses
+                those fundamentals into sliders and inputs, showing immediately how each
+                choice affects your total bill and effective rate. It is intentionally
+                exploratory—run as many what-if calculations as you need without waiting
+                for a spreadsheet to catch up.
+              </Typography>
+            </Box>
+
+            <Box>
+              <Typography variant="h6" gutterBottom>
+                What you can do here
+              </Typography>
+              <Box component="ul" sx={{ pl: 3, color: 'text.secondary', m: 0 }}>
+                <Box component="li" sx={{ mb: 1 }}>
+                  Compare salary, dividend, and crypto gain combinations against the
+                  latest UK tax bands.
+                </Box>
+                <Box component="li" sx={{ mb: 1 }}>
+                  Visualise how relief schemes such as VCT, EIS, and SEIS offset income
+                  and capital gains tax liabilities.
+                </Box>
+                <Box component="li">
+                  Communicate results clearly with a breakdown of income tax, capital
+                  gains tax, and total relief claimed.
+                </Box>
+              </Box>
+            </Box>
+
+            <Divider />
+
+            <Box
+              display="flex"
+              flexDirection={{ xs: 'column', sm: 'row' }}
+              alignItems={{ xs: 'flex-start', sm: 'center' }}
+              gap={3}
+            >
+              <Avatar
+                sx={{
+                  bgcolor: 'primary.main',
+                  width: 72,
+                  height: 72,
+                  fontSize: '1.75rem',
+                  fontWeight: 600,
+                }}
+              >
+                TS
+              </Avatar>
+              <Box>
+                <Typography variant="h6" gutterBottom>
+                  Meet the author
+                </Typography>
+                <Typography variant="body2" color="text.secondary" sx={{ mb: 1.5 }}>
+                  Tax Strategy Calculator is curated by an independent developer and
+                  finance enthusiast who shares insights under the moniker
+                  <strong> Tax Strat Dev</strong>. Their background spans full-stack
+                  engineering and personal finance coaching, with a focus on demystifying
+                  allowances, reliefs, and incentives for early-stage founders and
+                  investors.
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Beyond the calculator, the author publishes walkthroughs on making tax
+                  planning approachable, answers community questions, and keeps the app
+                  aligned with the latest HMRC guidance.
+                </Typography>
+              </Box>
+            </Box>
+
+            <Divider />
+
+            <Box textAlign="center">
+              <Typography variant="body1" color="text.secondary" sx={{ mb: 2 }}>
+                Ready to experiment with your own numbers?
+              </Typography>
+              <Button
+                variant="contained"
+                size="large"
+                component={RouterLink}
+                to="/"
+                sx={{
+                  textTransform: 'none',
+                  fontWeight: 600,
+                  px: 4,
+                  py: 1.5,
+                  borderRadius: 2,
+                  background: 'linear-gradient(90deg, #2563eb, #1d4ed8)',
+                  boxShadow: '0 12px 30px rgba(37, 99, 235, 0.35)',
+                  '&:hover': {
+                    background: 'linear-gradient(90deg, #1d4ed8, #2563eb)',
+                  },
+                }}
+              >
+                Open the calculator
+              </Button>
+            </Box>
+          </Stack>
+        </CardContent>
+      </Card>
+    </Container>
+  );
+};
+
+export default AboutPage;

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,63 @@
 import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
+import { AppBar, Toolbar, Typography, Button, Box } from '@mui/material';
 import TaxCalculator from './TaxCalculator';
+import AboutPage from './AboutPage';
+
 function App() {
-  return <TaxCalculator />;
+  return (
+    <Router>
+      <Box display="flex" flexDirection="column" minHeight="100vh">
+        <AppBar
+          position="static"
+          sx={{
+            background: 'linear-gradient(90deg, #2563eb, #1d4ed8)',
+            boxShadow: '0 10px 30px rgba(37, 99, 235, 0.35)',
+          }}
+        >
+          <Toolbar sx={{ display: 'flex', justifyContent: 'space-between' }}>
+            <Typography
+              variant="h6"
+              component={Link}
+              to="/"
+              sx={{
+                textDecoration: 'none',
+                color: 'common.white',
+                fontWeight: 600,
+                letterSpacing: 0.4,
+              }}
+            >
+              Tax Strategy Calculator
+            </Typography>
+            <Box>
+              <Button
+                component={Link}
+                to="/"
+                color="inherit"
+                sx={{ textTransform: 'none', fontWeight: 500, mr: 1 }}
+              >
+                Calculator
+              </Button>
+              <Button
+                component={Link}
+                to="/about"
+                color="inherit"
+                sx={{ textTransform: 'none', fontWeight: 500 }}
+              >
+                About
+              </Button>
+            </Box>
+          </Toolbar>
+        </AppBar>
+        <Box component="main" sx={{ flexGrow: 1, display: 'flex' }}>
+          <Routes>
+            <Route path="/" element={<TaxCalculator />} />
+            <Route path="/about" element={<AboutPage />} />
+          </Routes>
+        </Box>
+      </Box>
+    </Router>
+  );
 }
+
 export default App;

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,9 +1,18 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import App from './App';
 
-test('renders heading', () => {
+test('renders calculator heading inside main content', () => {
   render(<App />);
-  const heading = screen.getByText(/Tax Strategy Calculator/i);
+  const main = screen.getByRole('main');
+  const heading = within(main).getByRole('heading', {
+    name: /Tax Strategy Calculator/i,
+  });
   expect(heading).toBeInTheDocument();
+});
+
+test('shows navigation link for the about page', () => {
+  render(<App />);
+  const aboutLink = screen.getByRole('link', { name: /about/i });
+  expect(aboutLink).toBeInTheDocument();
 });

--- a/src/TaxCalculator.js
+++ b/src/TaxCalculator.js
@@ -117,7 +117,17 @@ const TaxCalculator = () => {
   };
 
   return (
-    <Box display="flex" justifyContent="center" alignItems="center" minHeight="100vh" p={3}>
+    <Box
+      display="flex"
+      justifyContent="center"
+      alignItems="center"
+      sx={{
+        minHeight: { xs: 'calc(100vh - 56px)', sm: 'calc(100vh - 64px)' },
+        py: { xs: 4, md: 6 },
+        px: { xs: 2, sm: 3 },
+        width: '100%',
+      }}
+    >
       <Card sx={{ width: "100%", maxWidth: 700 }}>
         <CardContent>
           <Typography variant="h4" align="center" gutterBottom>


### PR DESCRIPTION
## Summary
- integrate react-router navigation with a gradient app bar for calculator and about routes
- build a dedicated about page that highlights the calculator’s purpose and author background
- tune calculator layout spacing and record CRA browserslist targets for local development

## Testing
- npm test -- --watchAll=false

------
https://chatgpt.com/codex/tasks/task_e_68cae021ba84832e807e1c146fcc4f22